### PR TITLE
Fix Solana metadata output for CM

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -146,7 +146,7 @@ const addMetadata = (_dna, _edition) => {
       description: tempMetadata.description,
       //Added metadata for solana
       seller_fee_basis_points: solanaMetadata.seller_fee_basis_points,
-      image: `image.png`,
+      image: `${_edition}.png`,
       //Added metadata for solana
       external_url: solanaMetadata.external_url,
       edition: _edition,
@@ -155,7 +155,7 @@ const addMetadata = (_dna, _edition) => {
       properties: {
         files: [
           {
-            uri: "image.png",
+            uri: `${_edition}.png`,
             type: "image/png",
           },
         ],


### PR DESCRIPTION
Current solana metadata output is wrong as candy machine expects numbers 0.png, 1.png etc... instead of image.png for image and url. This PR fixes this bug.